### PR TITLE
Update block_tld_dns_query_policy.ps1

### DIFF
--- a/block_tld_dns_query_policy.ps1
+++ b/block_tld_dns_query_policy.ps1
@@ -1,19 +1,17 @@
 #thanks @SamErde
 
- Get-DnsServerQueryResolutionPolicy | Remove-DnsServerQueryResolutionPolicy -Force
+# If you're looking to specifically reset your block list each time, you could:
+(Get-DnsServerQueryResolutionPolicy).Where({ $_.Name -like "block - *" }) | Remove-DnsServerQueryResolutionPolicy -Force
 
-$badtld = Get-Content malic-dns-tld.txt
+$badtld = Get-Content -Path .\malic-dns-tld.txt | Sort-Object -Unique
 
-$badtld = $badtld | Sort-Object -Unique
+foreach ($tld in $badtld) {
 
-foreach($tld in $badtld){
+ $blockname = "block - " + $tld  
+ #$domainname = "." + $tld
+ $domainname = "EQ,*." + $tld
 
-$blockname = "block - " + $tld  
-#$domainname = "." + $tld
-$domainname = "EQ,*." + $tld
-
-$domainname
-Add-DnsServerQueryResolutionPolicy -Name $blockname.ToString() -Action IGNORE -FQDN $domainname.tostring() 
-
+ $domainname
+ Add-DnsServerQueryResolutionPolicy -Name $blockname -Action IGNORE -FQDN $domainname
 
 }


### PR DESCRIPTION
A few ideas, if you like!
The first is a guess that you might want to reset your block list before importing a fresh list. This change only removes query resolution policies that have names beginning with the string "block - ". 
The second suggestion is just to combine your Import-Content and Sort-Object cmdlets into one statement.
Hope this helps!